### PR TITLE
Added Damage System and Respawning

### DIFF
--- a/Leap and Learn/Assets/Prefab/Car 1.prefab
+++ b/Leap and Learn/Assets/Prefab/Car 1.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 8429409145426610320}
   m_Layer: 7
   m_Name: Car 1
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -133,7 +133,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 1, y: 0.8}
   m_EdgeRadius: 0
 --- !u!114 &8429409145426610320
 MonoBehaviour:

--- a/Leap and Learn/Assets/Prefab/Long Log.prefab
+++ b/Leap and Learn/Assets/Prefab/Long Log.prefab
@@ -26,7 +26,7 @@ Transform:
   m_GameObject: {fileID: 242805125519893999}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.3858056, y: 0, z: 0}
+  m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -113,7 +113,7 @@ Transform:
   m_GameObject: {fileID: 448846604610526607}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.6141945, y: 0, z: 0}
+  m_LocalPosition: {x: -3, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -200,7 +200,7 @@ Transform:
   m_GameObject: {fileID: 1460046542165450513}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.3858055, y: 0, z: 0}
+  m_LocalPosition: {x: -2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -391,7 +391,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 1.4, y: 0}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -445,7 +445,7 @@ Transform:
   m_GameObject: {fileID: 2481349354837735535}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4.3858056, y: 0, z: 0}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -532,7 +532,7 @@ Transform:
   m_GameObject: {fileID: 3370105607934777273}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.6141945, y: 0, z: 0}
+  m_LocalPosition: {x: -1, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -619,7 +619,7 @@ Transform:
   m_GameObject: {fileID: 7977275545499918557}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.3858055, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -706,7 +706,7 @@ Transform:
   m_GameObject: {fileID: 8795488977028321515}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2.3858056, y: 0, z: 0}
+  m_LocalPosition: {x: 1, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Leap and Learn/Assets/Prefab/Mid Log.prefab
+++ b/Leap and Learn/Assets/Prefab/Mid Log.prefab
@@ -26,7 +26,7 @@ Transform:
   m_GameObject: {fileID: 325919740303791911}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1, y: 0, z: 1}
+  m_LocalPosition: {x: 2, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -113,7 +113,7 @@ Transform:
   m_GameObject: {fileID: 544878216028992227}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3, y: 0, z: 1}
+  m_LocalPosition: {x: -2, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -200,7 +200,7 @@ Transform:
   m_GameObject: {fileID: 723419348871564420}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1, y: 0, z: 1}
+  m_LocalPosition: {x: 1, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -287,7 +287,7 @@ Transform:
   m_GameObject: {fileID: 3453735865778340847}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2, y: 0, z: 1}
+  m_LocalPosition: {x: -1, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -563,7 +563,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: -1, y: 0}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}

--- a/Leap and Learn/Assets/Prefab/Short Log.prefab
+++ b/Leap and Learn/Assets/Prefab/Short Log.prefab
@@ -26,7 +26,7 @@ Transform:
   m_GameObject: {fileID: 318228818796383539}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3, y: 0, z: 1}
+  m_LocalPosition: {x: 1, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -113,7 +113,7 @@ Transform:
   m_GameObject: {fileID: 4635206826775083210}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1, y: 0, z: 1}
+  m_LocalPosition: {x: -1, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -300,7 +300,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 2, y: 0}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -354,8 +354,8 @@ Transform:
   m_GameObject: {fileID: 8386098525772013276}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: 0, z: 1}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: -0.005, y: 0, z: 1}
+  m_LocalScale: {x: 1.01, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9059303784946198367}

--- a/Leap and Learn/Assets/Scenes/main.unity
+++ b/Leap and Learn/Assets/Scenes/main.unity
@@ -2756,6 +2756,8 @@ MonoBehaviour:
   currentQuestion: 
   idleSprite: {fileID: 21300000, guid: accdfca821fcfad4aa0e79fe4138f7df, type: 3}
   leapSprite: {fileID: 21300000, guid: c032d92b984378d4ebe60f300734cb08, type: 3}
+  froghealth: {fileID: 0}
+  respawnLocation: 0
 --- !u!50 &1840563115
 Rigidbody2D:
   serializedVersion: 5
@@ -2872,7 +2874,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 2
   m_Sprite: {fileID: 21300000, guid: accdfca821fcfad4aa0e79fe4138f7df, type: 3}
   m_Color: {r: 0.10578135, g: 0.6754716, b: 0.21092084, a: 1}
   m_FlipX: 0

--- a/Leap and Learn/Assets/Scripts/frog/frogMovement.cs
+++ b/Leap and Learn/Assets/Scripts/frog/frogMovement.cs
@@ -1,18 +1,22 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 
 public class frogMovement : MonoBehaviour
 {
-
     private SpriteRenderer spriteRenderer;
     public QuestionManager questionManager;
     public AnswerField answerField;
-    // varibale for the user input box
+    // variable for the user input box
     public TMP_InputField answerInputField;
     public TextMeshProUGUI textDisplay;
-    
+
+    // Locations for the frog to interact with
+    Queue<Queue<int>> dangerLanes;
+    Queue<Queue<int>> respawnLanes;
+
     // if the frog can move or not
     public bool canMove;
     public bool hasMoved;
@@ -21,16 +25,28 @@ public class frogMovement : MonoBehaviour
     private frogHealth health;
 
     public Sprite idleSprite;
-
     public Sprite leapSprite;
+
+
+    public frogHealth froghealth;
+
+    public int respawnLocation;
+
 
     // Called before start
     public void Awake()
     {
         health = GetComponent<frogHealth>();
-
+        respawnLocation = -5;
         canMove = false;
         hasMoved = true;
+
+        // Get the lane info
+        GameObject levelSpawner = GameObject.Find("levelSpawner");
+        levelSpawnScript levelScript = levelSpawner.GetComponent<levelSpawnScript>();
+        dangerLanes = levelScript.dangerLanes;
+        respawnLanes = levelScript.respawnLanes;
+
         spriteRenderer = GetComponent<SpriteRenderer>();
         textDisplay = GameObject.Find("AnswerTextUI").GetComponent<TextMeshProUGUI>();
         // finds the specific UI TextInput which allows us to actually use the input box in relation to movement
@@ -54,7 +70,7 @@ public class frogMovement : MonoBehaviour
     void Update()
     {
         // hasMoved set to allow movement only after correct answer in AnswerField.cs    
-        if (!hasMoved) {
+        if (hasMoved) {
             if(Input.GetKeyDown(KeyCode.A) || Input.GetKeyDown(KeyCode.LeftArrow))
             {
                 transform.rotation = Quaternion.Euler(0f, 0f, 90f);
@@ -99,29 +115,37 @@ public class frogMovement : MonoBehaviour
     {
         Vector3 movePos = transform.position + direction;
 
-        Collider2D platform = Physics2D.OverlapBox(movePos, Vector2.zero, 0f, LayerMask.GetMask("Platform"));
-        Collider2D obstacle = Physics2D.OverlapBox(movePos, Vector2.zero, 0f, LayerMask.GetMask("Obstacle"));
-
-
-        if (platform != null)
-        {
-            transform.SetParent(platform.transform);
-        } 
-        else
-        {
-            transform.SetParent(null);
-        }
-        if (obstacle != null)
-        {
-            health.LoseHeart();
-        }
-
-        
-        // Prevents the player from moving off the edge of the screen
         if ((movePos.x >= -5) && (movePos.x <= 5))
         {
             StartCoroutine(LeapAnimation(movePos));
         }
+
+        Collider2D platform = Physics2D.OverlapBox(movePos, Vector2.zero, 0f, LayerMask.GetMask("Platform"));
+        Collider2D obstacle = Physics2D.OverlapBox(movePos, Vector2.zero, 0f, LayerMask.GetMask("Obstacle"));
+
+        if (platform != null)
+        {
+            transform.SetParent(platform.transform);
+        }
+        else
+        {
+            transform.SetParent(null);
+        }
+
+        // Check if drowning
+        if (transform.parent == null && checkIfLane((int)movePos.y, dangerLanes))
+        {
+            health.LoseHeart();
+            respawn();
+        }
+        // Check if safe
+        if (checkIfLane((int)movePos.y, respawnLanes))
+        {
+            respawnLocation = (int)movePos.y;
+            Debug.Log("New Respawn Point");
+            Debug.Log(respawnLocation);
+        }
+
     }
 
     private IEnumerator LeapAnimation(Vector3 destination)
@@ -152,5 +176,36 @@ public class frogMovement : MonoBehaviour
 
     public void lockMovement() {
         canMove = false;
+    }
+
+    private bool checkIfLane(int location, Queue<Queue<int>> lanes)
+    {
+        foreach (Queue<int> innerQueue in lanes)
+        {
+            foreach (int lane in innerQueue)
+            {
+                if (lane == location)
+                {
+                    return true; 
+                }
+            }
+        }
+        return false;
+    }
+
+    private void respawn()
+    {
+        StopAllCoroutines();
+        Debug.Log("Respawn");
+        Vector3 spawnPoint = new Vector3(0, respawnLocation, 0);
+        transform.position = spawnPoint;
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.gameObject.layer == LayerMask.NameToLayer("Obstacle")) {
+            health.LoseHeart();
+            respawn();
+        }
     }
 }

--- a/Leap and Learn/Assets/Scripts/frog/frogMovement.cs
+++ b/Leap and Learn/Assets/Scripts/frog/frogMovement.cs
@@ -9,7 +9,7 @@ public class frogMovement : MonoBehaviour
     private SpriteRenderer spriteRenderer;
     public QuestionManager questionManager;
     public AnswerField answerField;
-    // variable for the user input box
+    // Variable for the user input box
     public TMP_InputField answerInputField;
     public TextMeshProUGUI textDisplay;
 
@@ -17,7 +17,7 @@ public class frogMovement : MonoBehaviour
     Queue<Queue<int>> dangerLanes;
     Queue<Queue<int>> respawnLanes;
 
-    // if the frog can move or not
+    // If the frog can move or not
     public bool canMove;
     public bool hasMoved;
     public string currentQuestion;
@@ -27,9 +27,6 @@ public class frogMovement : MonoBehaviour
     public Sprite idleSprite;
     public Sprite leapSprite;
 
-
-    public frogHealth froghealth;
-
     public int respawnLocation;
 
 
@@ -38,7 +35,7 @@ public class frogMovement : MonoBehaviour
     {
         health = GetComponent<frogHealth>();
         respawnLocation = -5;
-        canMove = false;
+        canMove = true;
         hasMoved = true;
 
         // Get the lane info
@@ -69,8 +66,8 @@ public class frogMovement : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        // hasMoved set to allow movement only after correct answer in AnswerField.cs    
-        if (hasMoved) {
+        // hasMoved set to allow movement only after correct answer in AnswerField.cs
+        if (!hasMoved && canMove) {
             if(Input.GetKeyDown(KeyCode.A) || Input.GetKeyDown(KeyCode.LeftArrow))
             {
                 transform.rotation = Quaternion.Euler(0f, 0f, 90f);
@@ -150,6 +147,7 @@ public class frogMovement : MonoBehaviour
 
     private IEnumerator LeapAnimation(Vector3 destination)
     {
+        lockMovement();
         Vector3 startPos = transform.position;
 
         float elapsed = 0f;
@@ -168,6 +166,7 @@ public class frogMovement : MonoBehaviour
         transform.position = destination;
 
         spriteRenderer.sprite = idleSprite;
+        unlockMovement();
     }
 
     public void unlockMovement() {
@@ -199,6 +198,7 @@ public class frogMovement : MonoBehaviour
         Debug.Log("Respawn");
         Vector3 spawnPoint = new Vector3(0, respawnLocation, 0);
         transform.position = spawnPoint;
+        canMove = true;
     }
 
     private void OnTriggerEnter2D(Collider2D other)

--- a/Leap and Learn/Assets/Scripts/obstacles/obstacles.cs
+++ b/Leap and Learn/Assets/Scripts/obstacles/obstacles.cs
@@ -2,11 +2,9 @@ using UnityEngine;
 
 public class Obstacle : MonoBehaviour
 {
-
     public Vector2 direction = Vector2.right;
     public float speed = 1f;
     public int size = 1;
-    public Transform frog;
     private Vector3 leftEdge;
     private Vector3 rightEdge;
 
@@ -15,6 +13,10 @@ public class Obstacle : MonoBehaviour
         speed = newSpeed;
     }
 
+    public void SetSize(int newSize)
+    {
+        size = newSize;
+    }
 
     private void Start()
     {

--- a/Leap and Learn/ProjectSettings/TagManager.asset
+++ b/Leap and Learn/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 3
-  tags: []
+  tags:
+  - Obstacle
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
The frog now respawns to the last grass lane when damaged by collision with a car or falling into the water. The movement glitch has been fixed and the sprites for the logs have been adjusted to properly be placed down. Obstacle and log spawning logic has been changed in order to prevent overlap.